### PR TITLE
[v1.4] Increase refresh rate, fix small text on some devices

### DIFF
--- a/StreamDeck.ColorPicker/StreamDeck.ColorPicker/Helpers/ImageHelper.cs
+++ b/StreamDeck.ColorPicker/StreamDeck.ColorPicker/Helpers/ImageHelper.cs
@@ -17,7 +17,7 @@ namespace StreamDeck.ColorPicker.Helpers
         internal static Font ResizeFont(Graphics graphics, string text, Font font)
         {
             var newSize = graphics.MeasureString(text, font);
-            if (newSize.Width > 142)
+            if (newSize.Width > 142 || newSize.Height > 142)
             {
                 return ResizeFont(graphics, text, new Font("Consolas", font.Size - 2, FontStyle.Bold, GraphicsUnit.Pixel));
             }
@@ -33,7 +33,7 @@ namespace StreamDeck.ColorPicker.Helpers
 
             using (var graphics = Graphics.FromImage(image))
             {
-                if (!isRGB) font = ResizeFont(graphics, text, font);
+                font = ResizeFont(graphics, text, font);
                 graphics.DrawString(text, font, isDarkColor ? Brushes.White : Brushes.Black, !isRGB ? 72 : 5 , 72, stringFormat);
             }
 

--- a/StreamDeck.ColorPicker/StreamDeck.ColorPicker/Models/FormatHex.cs
+++ b/StreamDeck.ColorPicker/StreamDeck.ColorPicker/Models/FormatHex.cs
@@ -7,7 +7,7 @@ namespace StreamDeck.ColorPicker.Models
     {
         internal override Font GetFont(string text)
         {
-            return new Font("Consolas", 14, FontStyle.Bold);
+            return new Font("Consolas", 120, FontStyle.Bold);
         }
 
         internal override StringFormat GetStringFormat()

--- a/StreamDeck.ColorPicker/StreamDeck.ColorPicker/Models/FormatRGB.cs
+++ b/StreamDeck.ColorPicker/StreamDeck.ColorPicker/Models/FormatRGB.cs
@@ -7,7 +7,7 @@ namespace StreamDeck.ColorPicker.Models
     {
         internal override Font GetFont(string text)
         {
-            return new Font("Consolas", 16, FontStyle.Bold);
+            return new Font("Consolas", 120, FontStyle.Bold);
         }
 
         internal override StringFormat GetStringFormat()

--- a/StreamDeck.ColorPicker/StreamDeck.ColorPicker/StaticPicker.cs
+++ b/StreamDeck.ColorPicker/StreamDeck.ColorPicker/StaticPicker.cs
@@ -2,6 +2,7 @@
 using Newtonsoft.Json.Linq;
 using StreamDeck.ColorPicker.Models;
 using System;
+using System.Timers;
 
 namespace StreamDeck.ColorPicker
 {
@@ -13,6 +14,7 @@ namespace StreamDeck.ColorPicker
         #region Private Members
 
         private static PluginSettings settings;
+        private readonly Timer timer;
 
         #endregion
         public StaticPicker(SDConnection connection, InitialPayload payload) : base(connection, payload)
@@ -22,10 +24,17 @@ namespace StreamDeck.ColorPicker
                 : payload.Settings.ToObject<PluginSettings>();
 
             SetPicker();
+
+            timer = new Timer(10);
+            timer.Elapsed += new ElapsedEventHandler(CustomTick);
+            timer.Enabled = false;
+            timer.Start();
         }
 
         public override void Dispose()
         {
+            timer.Stop();
+            timer.Dispose();
             Logger.Instance.LogMessage(TracingLevel.INFO, $"Destructor called");
         }
 
@@ -33,7 +42,9 @@ namespace StreamDeck.ColorPicker
 
         public override void KeyReleased(KeyPayload payload) { }
 
-        public override void OnTick() => UpdateKey(onTick: true);
+        public override void OnTick() { }
+
+        private void CustomTick(object sender, ElapsedEventArgs e) => UpdateKey(onTick: true);
 
         public void UpdateKey(bool onTick)
         {


### PR DESCRIPTION
- Increment the refresh rate to 10ms by implementing own timer
- Fixes an issue where the picker would stop working if a folder or another profile was selected
- Fixes an issue where on some devices the font would be too small